### PR TITLE
Feature-6: Angle-to-light approach for triangle shading

### DIFF
--- a/pipeline/helpers/triangle.py
+++ b/pipeline/helpers/triangle.py
@@ -10,5 +10,12 @@ class Triangle:
     """
     Triangle = TypeVar("Triangle")
 
-    def __init__(self, p1: Vec3, p2: Vec3, p3: Vec3):
+    def __init__(
+            self,
+            p1: Vec3,
+            p2: Vec3,
+            p3: Vec3,
+            angle_to_light=None,   # Used to determine intensity of color when drawn
+    ):
         self.p = [p1, p2, p3]
+        self.angle_to_light = angle_to_light

--- a/pipeline/renderer.py
+++ b/pipeline/renderer.py
@@ -103,18 +103,17 @@ class Renderer:
         return tri_projected
 
     @staticmethod
-    def _calculate_shade_of_triangle(tri: Triangle):
+    def _calculate_shade_of_triangle(tri: Triangle) -> Color:
         """
         Calculate the shade of a color based on triangles angle to light
 
-        As we draw only white for now, I use hardcoded values of shades of white
+        Using color in HLS color space we can manipulate the illumination
         """
         dot_value = tri.angle_to_light
-        base_color = Color(Color.RGB, 0, 255, 0)
+        base_color = Color(Color.RGB, 0, 255, 0)  # Use Green for now
 
+        # Change illumination of triangle based on angle
         color_hls_form = base_color.to_hls()
-
-        # Change ilumination of triangle
         color_hls_form[1] *= dot_value
 
         shade_of_triangle = Color(Color.HLS, *color_hls_form)

--- a/pipeline/renderer.py
+++ b/pipeline/renderer.py
@@ -3,6 +3,7 @@ from tkinter import Canvas
 
 from math_3d.mat4x4 import Mat4x4
 from math_3d.vec3 import Vec3
+from pipeline.helpers.color import Color
 from pipeline.helpers.triangle import Triangle
 
 
@@ -109,27 +110,14 @@ class Renderer:
         As we draw only white for now, I use hardcoded values of shades of white
         """
         dot_value = tri.angle_to_light
+        base_color = Color(Color.RGB, 0, 255, 0)
 
-        if dot_value <= 0.1:
-            shade_of_triangle = "#191919"
-        elif dot_value <= 0.2:
-            shade_of_triangle = "#323232"
-        elif dot_value <= 0.3:
-            shade_of_triangle = "#4c4c4c"
-        elif dot_value <= 0.4:
-            shade_of_triangle = "#666666"
-        elif dot_value <= 0.5:
-            shade_of_triangle = "#7f7f7f"
-        elif dot_value <= 0.6:
-            shade_of_triangle = "#999999"
-        elif dot_value <= 0.7:
-            shade_of_triangle = "#b2b2b2"
-        elif dot_value <= 0.8:
-            shade_of_triangle = "#cccccc"
-        elif dot_value <= 0.9:
-            shade_of_triangle = "#e5e5e5"
-        else:
-            shade_of_triangle = "#ffffff"
+        color_hls_form = base_color.to_hls()
+
+        # Change ilumination of triangle
+        color_hls_form[1] *= dot_value
+
+        shade_of_triangle = Color(Color.HLS, *color_hls_form)
 
         return shade_of_triangle
 
@@ -143,7 +131,7 @@ class Renderer:
         points = [tri.p[0].x, tri.p[0].y, tri.p[1].x, tri.p[1].y, tri.p[2].x, tri.p[2].y]
         shade_of_triangle = Renderer._calculate_shade_of_triangle(tri)
 
-        window.create_polygon(points, outline="red", fill=shade_of_triangle)
+        window.create_polygon(points, outline="red", fill=shade_of_triangle.to_hex())
 
     def _scale_triangle(self, tri: Triangle) -> Triangle:
         """

--- a/pipeline/renderer.py
+++ b/pipeline/renderer.py
@@ -102,6 +102,38 @@ class Renderer:
         return tri_projected
 
     @staticmethod
+    def _calculate_shade_of_triangle(tri: Triangle):
+        """
+        Calculate the shade of a color based on triangles angle to light
+
+        As we draw only white for now, I use hardcoded values of shades of white
+        """
+        dot_value = tri.angle_to_light
+
+        if dot_value <= 0.1:
+            shade_of_triangle = "#191919"
+        elif dot_value <= 0.2:
+            shade_of_triangle = "#323232"
+        elif dot_value <= 0.3:
+            shade_of_triangle = "#4c4c4c"
+        elif dot_value <= 0.4:
+            shade_of_triangle = "#666666"
+        elif dot_value <= 0.5:
+            shade_of_triangle = "#7f7f7f"
+        elif dot_value <= 0.6:
+            shade_of_triangle = "#999999"
+        elif dot_value <= 0.7:
+            shade_of_triangle = "#b2b2b2"
+        elif dot_value <= 0.8:
+            shade_of_triangle = "#cccccc"
+        elif dot_value <= 0.9:
+            shade_of_triangle = "#e5e5e5"
+        else:
+            shade_of_triangle = "#ffffff"
+
+        return shade_of_triangle
+
+    @staticmethod
     def _draw_triangle(tri: Triangle, window: Canvas) -> None:
         """
         Draw triangle to screen
@@ -109,8 +141,9 @@ class Renderer:
         :param tri: Triangle to be drawn
         """
         points = [tri.p[0].x, tri.p[0].y, tri.p[1].x, tri.p[1].y, tri.p[2].x, tri.p[2].y]
+        shade_of_triangle = Renderer._calculate_shade_of_triangle(tri)
 
-        window.create_polygon(points, outline="white", fill="")
+        window.create_polygon(points, outline="red", fill=shade_of_triangle)
 
     def _scale_triangle(self, tri: Triangle) -> Triangle:
         """
@@ -202,6 +235,8 @@ class Renderer:
                 if normal * (tri_translated.p[0] - self.camera) < 0.0:
                     # Illuminate triangle
                     light_direction = Vec3(0.0, 0.0, -1.0).normalize()  # towards the camera
+                    dot_product =  light_direction * normal
+                    tri_translated.angle_to_light = dot_product
 
                     # Project triangles
                     tri_projected = self._project_triangle(tri_translated)


### PR DESCRIPTION
A very simple approach to getting the shade of a triangle's color based on the angle to the directional light of a scene. I need to find a simple and generic approach for actually getting the color's shade and not use hardcoded values. 

Tkinter doesn't have a color class, it uses `hex` values. Maybe I will have to create my own color class. This would be handy for the later texture support. If we want to go for a Gouraud shading that would be also helpful. 

Is there a better way of getting values from switch-case based on range? Some fancy list comprehension?