### PR TITLE
Feature-10: Add HLS color support

### DIFF
--- a/pipeline/helpers/color.py
+++ b/pipeline/helpers/color.py
@@ -1,0 +1,88 @@
+"""
+Color representation stored in an object.
+Can cast color to RGB and HLS representations.
+
+For  calculating shadows, RGB doesn't have a `intensity` parameter allowing for
+brighter or darker colors. One solution to this problem is using HLS
+(Hue, Luminance, Saturation) representation of RGB color space.
+"""
+import colorsys
+from typing import Union
+
+
+class Color:
+    """
+    Simple color class to keep color values and allow for conversion
+    between color spaces [RGB, HLS]
+    """
+    RGB = "rgb"
+    HLS = "hls"
+
+    def __init__(self, space: Union[RGB, HLS], *args):
+        if len(args) != 3:
+            raise ValueError("There can be only 3 values for a color space")
+
+        # Validate that values are correct
+        Color.__validate_values(space, args)
+
+        self.space = space
+        self.color_values = args
+
+    def to_rgb(self):
+        # Convert Hue to float value
+        values = list(self.color_values)
+        values[0] = values[0]/360
+
+        # Get converted colors from HLS to RGB as floats
+        converted = colorsys.hls_to_rgb(*values)
+
+        # Convert those floats to ints in range [0, 255]
+        converted = list(map(lambda value: round(value*255), converted))
+        return converted
+
+    def to_hls(self):
+        # Convert RGB ints to floats
+        as_floats = list(map(lambda value: round(value/255), self.color_values))
+
+        # Convert to HLS
+        converted = list(colorsys.rgb_to_hls(*as_floats))
+
+        # Represent Hue as degrees
+        converted[0] = round(converted[0]*360)
+
+        return converted
+
+    @staticmethod
+    def __validate_values(space, args):
+        if space == Color.RGB:
+            Color.__check_rgb_values(args)
+        elif space == Color.HLS:
+            Color.__check_hls_values(args)
+        else:
+            raise ValueError(f"Wrong value: {space} - Value of color space has"
+                             f"to be {Color.HLS}, {Color.RGB}")
+
+    @staticmethod
+    def __check_rgb_values(values):
+        # RGB values have to be between 0 and 255
+        for value in values:
+            if isinstance(value, int) and 0 <= value <= 255:
+                continue
+            else:
+                raise ValueError(f"Wrong value: {value} - Values for RGB have"
+                                 "to be between 0 and 255.")
+
+    @staticmethod
+    def __check_hls_values(values):
+        hue = values[0]
+        # Hue has to be between [0, 360]
+        if not (isinstance(hue, int) and 0 <= hue <= 360):
+            raise ValueError(f"Wrong value for Hue: {hue} - Hue has to be"
+                             "between 0 and 360")
+
+        # Check Luminance and Saturation
+        for index in range(1, 3):
+            val = values[index]
+            if not 0 <= val <= 1:
+                raise ValueError(f"Wrong value: {val} - Luminance and "
+                                 "Saturation have to be between 0 and 1")

--- a/pipeline/helpers/color.py
+++ b/pipeline/helpers/color.py
@@ -29,8 +29,13 @@ class Color:
         self.color_values = args
 
     def to_rgb(self):
-        # Convert Hue to float value
         values = list(self.color_values)
+
+        # Check if we're already RGB
+        if self.space == Color.RGB:
+            return values
+
+        # Convert Hue to float value
         values[0] = values[0]/360
 
         # Get converted colors from HLS to RGB as floats
@@ -41,6 +46,10 @@ class Color:
         return converted
 
     def to_hls(self):
+        # Check if we're already hls
+        if self.space == Color.HLS:
+            return list(self.color_values)
+
         # Convert RGB ints to floats
         as_floats = list(map(lambda value: round(value/255), self.color_values))
 
@@ -51,6 +60,14 @@ class Color:
         converted[0] = round(converted[0]*360)
 
         return converted
+
+    def to_hex(self):
+        # Get RGB representation
+        as_rgb = self.to_rgb()
+
+        # To hex
+        as_hex = "#%02x%02x%02x" % tuple(as_rgb)
+        return as_hex
 
     @staticmethod
     def __validate_values(space, args):

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,0 +1,60 @@
+import unittest
+from pipeline.helpers.color import Color
+
+
+class TestColor(unittest.TestCase):
+    """
+    Unit tests for Color
+    """
+
+    def test_color(self):
+        """Test color constructor on happy path"""
+        temp_rgb = Color(Color.RGB, 0, 255, 0)
+        temp_hls = Color(Color.HLS, 0, 1, 1)
+
+        self.assertIsInstance(temp_rgb, Color)
+        self.assertIsInstance(temp_hls, Color)
+
+    def test_raises_args_length(self):
+        """Test constructor raises if there aren't 3 values"""
+        with self.assertRaises(ValueError):
+            Color(Color.RGB, 0)
+
+    def test_raises_wrong_space(self):
+        """Test constructor raises if wrong color space used"""
+        with self.assertRaises(ValueError):
+            Color("wrong value", 0, 0, 0)
+
+    def test_raises_rgb_beyond_range(self):
+        """Test constructor raises if RGB values beyond range[0,255]"""
+        with self.assertRaises(ValueError):
+            Color(Color.RGB, 0, 0, -1)
+            Color(Color.RGB, 0, 0, 256)
+
+    def test_raises_hue_wrong_value(self):
+        """Test constructor raises if Hue beyond range[0, 360]"""
+        with self.assertRaises(ValueError):
+            Color(Color.HLS, -2, 0, 0)
+            Color(Color.HLS, 361, 0, 0)
+
+    def test_rgb_to_hls(self):
+        """Test green rgb conversion to hls"""
+        green_as_rgb = Color(Color.RGB, 0, 255, 0)
+        self.assertEqual([120, 0.5, 1.0], green_as_rgb.to_hls())
+
+    def test_hls_to_rgb(self):
+        """Test hls conversion to rgb"""
+        green_as_hls = Color(Color.HLS, 120, 0.5, 1.0)
+        self.assertEqual([0, 255, 0], green_as_hls.to_rgb())
+
+        red_as_hls = Color(Color.HLS, 0, 0.5, 1.0)
+        self.assertEqual([255, 0, 0], red_as_hls.to_rgb())
+
+        black_as_hls = Color(Color.HLS, 360, 0, 0)
+        self.assertEqual([0, 0, 0], black_as_hls.to_rgb())
+
+        black_as_hls_2 = Color(Color.HLS, 34, 0, 0)
+        self.assertEqual([0, 0, 0], black_as_hls_2.to_rgb())
+
+        white_as_hls = Color(Color.HLS, 357, 1, 0.21)
+        self.assertEqual([255, 255, 255], white_as_hls.to_rgb())

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -58,3 +58,11 @@ class TestColor(unittest.TestCase):
 
         white_as_hls = Color(Color.HLS, 357, 1, 0.21)
         self.assertEqual([255, 255, 255], white_as_hls.to_rgb())
+
+    def test_to_hex(self):
+        """Test conversion to hex"""
+        green_as_rgb = Color(Color.RGB, 0, 255, 0)
+        self.assertEqual("#00ff00", green_as_rgb.to_hex())
+
+        green_as_hls = Color(Color.HLS, *green_as_rgb.to_hls())
+        self.assertEqual("#00ff00", green_as_hls.to_hex())


### PR DESCRIPTION
Using pythons `colorsys`, I just wrote a simple wrapper around it to use commonly used values for:
- `RGB(int, int, int)`
- `HLS(int, float, float)`

Should be good enough for our shading purposes.